### PR TITLE
Ensure that permissions on docker volumes gets intialized correctly.

### DIFF
--- a/foreman/run_surveyor.sh
+++ b/foreman/run_surveyor.sh
@@ -17,7 +17,7 @@ cd ..
 volume_directory="$script_directory/volume"
 if [ ! -d "$volume_directory" ]; then
     mkdir $volume_directory
-    chmod 775 $volume_directory
+    chmod -R a+rwX $volume_directory
 fi
 
 docker build -t dr_foreman -f foreman/Dockerfile .

--- a/run_nomad.sh
+++ b/run_nomad.sh
@@ -12,6 +12,13 @@ script_directory=`perl -e 'use File::Basename;
  print dirname(abs_path(@ARGV[0]));' -- "$0"`
 cd $script_directory
 
+# Set up the data volume directory if it does not already exist
+volume_directory="$script_directory/volume"
+if [ ! -d "$volume_directory" ]; then
+    mkdir $volume_directory
+    chmod -R a+rwX $volume_directory
+fi
+
 source common.sh
 HOST_IP=$(get_ip_address)
 
@@ -26,7 +33,7 @@ fi
 nomad agent -bind $HOST_IP \
       -data-dir $nomad_dir \
       -dev \
-      > nomad.logs &
+      &> nomad.logs &
 
 # While we wait for Nomad to start, make sure the Docker registry has
 # an up-to-date Docker image for the workers sub-project. We run a

--- a/run_shell.sh
+++ b/run_shell.sh
@@ -21,7 +21,7 @@ cd $script_directory
 volume_directory="$script_directory/foreman/volume"
 if [ ! -d "$volume_directory" ]; then
     mkdir $volume_directory
-    chmod 775 $volume_directory
+    chmod -R a+rwX $volume_directory
 fi
 
 docker build -t dr_shell -f foreman/Dockerfile .

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -17,7 +17,7 @@ cd ..
 volume_directory="$script_directory/test_volume"
 if [ ! -d "$volume_directory" ]; then
     mkdir $volume_directory
-    chmod 775 $volume_directory
+    chmod -R a+rwX $volume_directory
 fi
 
 test_data_repo="https://s3.amazonaws.com/data-refinery-test-assets"

--- a/workers/worker.sh
+++ b/workers/worker.sh
@@ -17,7 +17,7 @@ cd ..
 volume_directory="$script_directory/volume"
 if [ ! -d "$volume_directory" ]; then
     mkdir $volume_directory
-    chmod 775 $volume_directory
+    chmod -R a+rwX $volume_directory
 fi
 
 docker build -t dr_worker -f workers/Dockerfile .


### PR DESCRIPTION
Rich and I ran into an issue where nomad containers could not write to their volumes. This will prevent this from happening when the project is setup on future boxes, however it will not retroactively fix the permissions for existing volumes.

This will also redirect stderr from Nomad into the nomad.logs file so the terminal doesn't output stuff randomly.