### PR TITLE
Fixes the creation of the volume for workers locally.

### DIFF
--- a/run_nomad.sh
+++ b/run_nomad.sh
@@ -13,7 +13,7 @@ script_directory=`perl -e 'use File::Basename;
 cd $script_directory
 
 # Set up the data volume directory if it does not already exist
-volume_directory="$script_directory/volume"
+volume_directory="$script_directory/workers/volume"
 if [ ! -d "$volume_directory" ]; then
     mkdir $volume_directory
     chmod -R a+rwX $volume_directory


### PR DESCRIPTION
This PR was written by @dongbohu @kurtwheeler while pairing so it is automatically approved!

## Issue Number

Just found and fixed this bug.

## Purpose/Implementation Notes

When setting up the project locally, `run_nomad.sh` failed to properly initialize the `workers/volume` directory.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

We ran a downloader job and saw it complete successfully, whereas before it failed because it could not use the local filestore.

## Checklist

_Put an `x` in the boxes that apply._

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
